### PR TITLE
Fix cv update

### DIFF
--- a/intact-bioactiveentities-update/pom.xml
+++ b/intact-bioactiveentities-update/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dbupdate-master</artifactId>
         <groupId>uk.ac.ebi.intact.dbupdate</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-bioactiveentities-update</artifactId>

--- a/intact-biosource-update/pom.xml
+++ b/intact-biosource-update/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dbupdate</groupId>
         <artifactId>dbupdate-master</artifactId>
-        <version>2.3.3</version>
+        <version>2.3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-biosource-update</artifactId>

--- a/intact-cv-update/pom.xml
+++ b/intact-cv-update/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>dbupdate-master</artifactId>
         <groupId>uk.ac.ebi.intact.dbupdate</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-cv-update</artifactId>

--- a/intact-cv-update/src/main/java/uk/ac/ebi/intact/dbupdate/cv/updater/CvAnnotationUpdaterImpl.java
+++ b/intact-cv-update/src/main/java/uk/ac/ebi/intact/dbupdate/cv/updater/CvAnnotationUpdaterImpl.java
@@ -1,7 +1,5 @@
 package uk.ac.ebi.intact.dbupdate.cv.updater;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import psidev.psi.mi.jami.bridges.ontologymanager.MIOntologyTermI;
@@ -30,8 +28,6 @@ import java.util.*;
 
 //TODO Deal with comments and URL
 public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
-
-    private static final Log log = LogFactory.getLog(CvAnnotationUpdaterImpl.class);
 
     private final TreeSet<psidev.psi.mi.jami.model.Annotation> sortedOntologyAnnotations;
     private final TreeSet<Annotation> sortedCvAnnotations;
@@ -216,7 +212,6 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
             }
             else {
                 // One definition annotation has been found already, we delete the extra ones
-                log.info("TESTING - Definition deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 deleteAnnotation(term, updateEvt);
             }
         }
@@ -227,7 +222,6 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
             }
             else {
                 // One url annotation has been found already, we delete the extra ones
-                log.info("TESTING - Definition deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 deleteAnnotation(term, updateEvt);
             }
         }
@@ -238,7 +232,6 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
             }
             else {
                 // One search url annotation has been found already, we delete the extra ones
-                log.info("TESTING - Definition deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 deleteAnnotation(term, updateEvt);
             }
         }
@@ -249,7 +242,6 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
             }
             else {
                 // One validation regex annotation has been found already, we delete the extra ones
-                log.info("TESTING - Definition deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 deleteAnnotation(term, updateEvt);
             }
         }
@@ -260,7 +252,6 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
             }
             else {
                 // One obsolete annotation has been found already, we delete the extra ones
-                log.info("TESTING - Definition deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 deleteAnnotation(term, updateEvt);
             }
         }
@@ -291,13 +282,11 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
 
                 // we update existing definition annotation with new text from ontology
                 if (!ontologyTerm.getDelegate().getDefinition().equalsIgnoreCase(currentIntact.getAnnotationText())) {
-                    log.info("TESTING - Definition updated for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                     updateAnnotation(updateEvt, ontologyTerm.getDelegate().getDefinition());
                 }
             }
             else {
                 // One definition annotation has been found already, we delete the extra ones
-                log.info("TESTING - Definition deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 deleteAnnotation(term, updateEvt);
             }
         }
@@ -308,7 +297,6 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
 
                 // we update existing obsolete annotation with new text from ontology
                 if (ontologyTerm.getObsoleteMessage() ==  null && currentIntact.getAnnotationText() != null) {
-                    log.info("TESTING - Obsolete updated for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                     updateAnnotation(updateEvt, null);
                 }
                 else if (ontologyTerm.getObsoleteMessage() !=  null && !ontologyTerm.getObsoleteMessage().equalsIgnoreCase(currentIntact.getAnnotationText())){
@@ -317,7 +305,6 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
             }
             else{
                 // One obsolete annotation has been found already, we delete the extra ones
-                log.info("TESTING - Obsolete deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 deleteAnnotation(term, updateEvt);
             }
         }
@@ -335,14 +322,12 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
             }
             // comment does not exist but can be updated with a newer comment from the ontology
             else if (!comments.contains(currentIntact.getAnnotationText()) && !comments.isEmpty()) {
-                log.info("TESTING - Comment updated for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 updateAnnotation(updateEvt, comments.iterator().next());
 
                 comments.remove(currentIntact.getAnnotationText());
             }
             // delete the comment annotation, as it does not exist in the ontology
             else {
-                log.info("TESTING - Comment deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 deleteAnnotation(term, updateEvt);
             }
         }
@@ -350,12 +335,10 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
         else if (CvTopic.URL_MI_REF.equalsIgnoreCase(cvTopic.getIdentifier())) {
             if (!hasFoundURL) {
                 // we update existing url annotation with new text from ontology
-                log.info("TESTING - Url updated for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 hasFoundURL = updateAnnotationIfFoundInOntology(ontologyTerm, updateEvt, CvTopic.URL_MI_REF, CvTopic.URL);
             }
             else {
                 // One url annotation has been found already, we delete the extra ones
-                log.info("TESTING - Url deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 deleteAnnotation(term, updateEvt);
             }
         }
@@ -363,13 +346,11 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
         else if (CvTopic.SEARCH_URL_MI_REF.equalsIgnoreCase(cvTopic.getIdentifier())) {
             if (!hasFoundSearchURL) {
                 // we update existing search url annotation with new text from ontology
-                log.info("TESTING - Search url updated for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 hasFoundSearchURL = updateAnnotationIfFoundInOntology(
                         ontologyTerm, updateEvt, CvTopic.SEARCH_URL_MI_REF, CvTopic.SEARCH_URL);
             }
             else {
                 // One search url annotation has been found already, we delete the extra ones
-                log.info("TESTING - Search url deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 deleteAnnotation(term, updateEvt);
             }
         }
@@ -377,13 +358,11 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
         else if (CvTopic.XREF_VALIDATION_REGEXP_MI_REF.equalsIgnoreCase(cvTopic.getIdentifier())) {
             if (!hasFoundValidationRegexp) {
                 // we update existing validation regex annotation with new text from ontology
-                log.info("TESTING - Validation regex updated for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 hasFoundValidationRegexp = updateAnnotationIfFoundInOntology(
                         ontologyTerm, updateEvt, CvTopic.XREF_VALIDATION_REGEXP_MI_REF, CvTopic.XREF_VALIDATION_REGEXP);
             }
             else {
                 // One validation regex annotation has been found already, we delete the extra ones
-                log.info("TESTING - Validation regex deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 deleteAnnotation(term, updateEvt);
             }
         }
@@ -424,7 +403,6 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
         if (CvTopic.DEFINITION.equalsIgnoreCase(cvTop.getShortLabel())) {
             if (!hasFoundDefinition) {
                 hasFoundDefinition = true;
-                log.info("TESTING - Definition created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 createNewAnnotation(cvTop, term, updateEvt, currentOntologyRef.getValue());
             }
         }
@@ -432,7 +410,6 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
         else if (CvTopic.URL.equalsIgnoreCase(cvTop.getShortLabel())) {
             if (!hasFoundURL) {
                 hasFoundURL = true;
-                log.info("TESTING - Url created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 createNewAnnotation(cvTop, term, updateEvt, currentOntologyRef.getValue());
             }
         }
@@ -440,7 +417,6 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
         else if (CvTopic.SEARCH_URL.equalsIgnoreCase(cvTop.getShortLabel())) {
             if (!hasFoundSearchURL) {
                 hasFoundSearchURL = true;
-                log.info("TESTING - Search url created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 createNewAnnotation(cvTop, term, updateEvt, currentOntologyRef.getValue());
             }
         }
@@ -448,7 +424,6 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
         else if (CvTopic.XREF_VALIDATION_REGEXP.equalsIgnoreCase(cvTop.getShortLabel())) {
             if (!hasFoundValidationRegexp) {
                 hasFoundValidationRegexp = true;
-                log.info("TESTING - Validation regex created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 createNewAnnotation(cvTop, term, updateEvt, currentOntologyRef.getValue());
             }
         }
@@ -456,7 +431,6 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
         else if (CvTopic.OBSOLETE.equalsIgnoreCase(cvTop.getShortLabel())) {
             if (!hasFoundObsolete) {
                 hasFoundObsolete = true;
-                log.info("TESTING - Obsolete created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 createNewAnnotation(cvTop, term, updateEvt, currentOntologyRef.getValue());
             }
         }
@@ -464,12 +438,10 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
         else if (CvTopic.COMMENT_MI_REF.equalsIgnoreCase(cvTop.getIdentifier())) {
             comment = cvTop;
             comments.remove(currentOntologyRef.getValue());
-            log.info("TESTING - Comment created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
             createNewAnnotation(cvTop, term, updateEvt, currentOntologyRef.getValue());
         }
         // we have another type of annotation, we simply create it in Intact
         else {
-            log.info("TESTING - Other (Topic = " + cvTop.getShortLabel() + ") created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
             createNewAnnotation(cvTop, term, updateEvt, currentOntologyRef.getValue());
         }
 
@@ -489,7 +461,6 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
 
         // create missing definition
         if (!hasFoundDefinition && ontologyTerm.getDelegate().getDefinition() != null) {
-            log.info("TESTING - Missing definition created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
             createNewAnnotationWithTopic(factory, term, updateEvt, ontologyTerm.getDelegate().getDefinition(), null, CvTopic.DEFINITION);
         }
 
@@ -498,7 +469,6 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
                 ontologyTerm.getDelegate().getAnnotations(),CvTopic.URL_MI_REF, CvTopic.URL);
 
         if (!hasFoundURL && urlAnnotation != null) {
-            log.info("TESTING - Missing url created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
             createNewAnnotationWithTopic(factory, term, updateEvt, urlAnnotation.getValue(), CvTopic.URL_MI_REF, CvTopic.URL);
         }
 
@@ -507,7 +477,6 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
                 ontologyTerm.getDelegate().getAnnotations(),CvTopic.SEARCH_URL_MI_REF, CvTopic.SEARCH_URL);
 
         if (!hasFoundSearchURL && searchUrlAnnotation != null) {
-            log.info("TESTING - Missing search url created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
             createNewAnnotationWithTopic(factory, term, updateEvt, searchUrlAnnotation.getValue(), CvTopic.SEARCH_URL_MI_REF, CvTopic.SEARCH_URL);
         }
 
@@ -516,19 +485,16 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
                 ontologyTerm.getDelegate().getAnnotations(),CvTopic.XREF_VALIDATION_REGEXP_MI_REF, CvTopic.XREF_VALIDATION_REGEXP);
 
         if (!hasFoundValidationRegexp && validationRegexAnnotation != null) {
-            log.info("TESTING - Missing validation regex created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
             createNewAnnotationWithTopic(factory, term, updateEvt, validationRegexAnnotation.getValue(), CvTopic.XREF_VALIDATION_REGEXP_MI_REF, CvTopic.XREF_VALIDATION_REGEXP);
         }
 
         // create missing obsolete
         if (!hasFoundObsolete && isObsolete) {
-            log.info("TESTING - Missing obsolete created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
             createNewAnnotationWithTopic(factory, term, updateEvt, ontologyTerm.getObsoleteMessage(), CvTopic.OBSOLETE_MI_REF, CvTopic.OBSOLETE);
         }
 
         // hide term if obsolete
         if (isObsolete && !isHidden) {
-            log.info("TESTING - Missing old obsolete created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
             Annotation hidden = CvUpdateUtils.hideTerm(term, CvTopic.OBSOLETE_OLD);
 
             if (updateEvt != null) {
@@ -548,7 +514,6 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
             }
 
             for (String com : comments) {
-                log.info("TESTING - Missing comment created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
                 createNewAnnotation(comment, term, updateEvt, com);
             }
         }

--- a/intact-cv-update/src/main/java/uk/ac/ebi/intact/dbupdate/cv/updater/CvAnnotationUpdaterImpl.java
+++ b/intact-cv-update/src/main/java/uk/ac/ebi/intact/dbupdate/cv/updater/CvAnnotationUpdaterImpl.java
@@ -191,7 +191,7 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
 
         // We have an exact match, the annotation from Intact and from the ontology contain the same text
         if (acComparator == 0) {
-            processAnnotationsWithExactMatch(intactIterator, ontologyIterator);
+            processAnnotationsWithExactMatch(term, updateEvt, intactIterator, ontologyIterator);
         }
         // Annotation from Intact has no match in ontology, we need to delete it
         else if (acComparator < 0) {
@@ -204,28 +204,65 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
     }
 
     private void processAnnotationsWithExactMatch(
+            CvDagObject term,
+            UpdatedEvent updateEvt,
             Iterator<Annotation> intactIterator,
             Iterator<psidev.psi.mi.jami.model.Annotation> ontologyIterator) {
 
-        // we have a definition. Only one is allowed
+        // we have a definition annotation. Only one is allowed
         if (CvTopic.DEFINITION.equalsIgnoreCase(cvTopic.getShortLabel())) {
-            hasFoundDefinition = true;
+            if (!hasFoundDefinition) {
+                hasFoundDefinition = true;
+            }
+            else {
+                // One definition annotation has been found already, we delete the extra ones
+                log.info("TESTING - Definition deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                deleteAnnotation(term, updateEvt);
+            }
         }
-        // we have a definition. Only one is allowed
+        // we have a url annotation. Only one is allowed
         else if (CvTopic.URL.equalsIgnoreCase(cvTopic.getShortLabel())) {
-            hasFoundURL = true;
+            if (!hasFoundURL) {
+                hasFoundURL = true;
+            }
+            else {
+                // One url annotation has been found already, we delete the extra ones
+                log.info("TESTING - Definition deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                deleteAnnotation(term, updateEvt);
+            }
         }
-        // we have a definition. Only one is allowed
+        // we have a search url annotation. Only one is allowed
         else if (CvTopic.SEARCH_URL.equalsIgnoreCase(cvTopic.getShortLabel())) {
-            hasFoundSearchURL = true;
+            if (!hasFoundSearchURL) {
+                hasFoundSearchURL = true;
+            }
+            else {
+                // One search url annotation has been found already, we delete the extra ones
+                log.info("TESTING - Definition deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                deleteAnnotation(term, updateEvt);
+            }
         }
-        // we have a definition. Only one is allowed
+        // we have a validation regex annotation. Only one is allowed
         else if (CvTopic.XREF_VALIDATION_REGEXP.equalsIgnoreCase(cvTopic.getShortLabel())) {
-            hasFoundValidationRegexp = true;
+            if (!hasFoundValidationRegexp) {
+                hasFoundValidationRegexp = true;
+            }
+            else {
+                // One validation regex annotation has been found already, we delete the extra ones
+                log.info("TESTING - Definition deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                deleteAnnotation(term, updateEvt);
+            }
         }
-        // we have a definition. Only one is allowed
+        // we have an obsolete annotation. Only one is allowed
         else if (CvTopic.OBSOLETE.equalsIgnoreCase(cvTopic.getShortLabel())) {
-            hasFoundObsolete = true;
+            if (!hasFoundObsolete) {
+                hasFoundObsolete = true;
+            }
+            else {
+                // One obsolete annotation has been found already, we delete the extra ones
+                log.info("TESTING - Definition deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                deleteAnnotation(term, updateEvt);
+            }
         }
 
         if (intactIterator.hasNext() && ontologyIterator.hasNext()) {

--- a/intact-cv-update/src/main/java/uk/ac/ebi/intact/dbupdate/cv/updater/CvAnnotationUpdaterImpl.java
+++ b/intact-cv-update/src/main/java/uk/ac/ebi/intact/dbupdate/cv/updater/CvAnnotationUpdaterImpl.java
@@ -1,5 +1,7 @@
 package uk.ac.ebi.intact.dbupdate.cv.updater;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import psidev.psi.mi.jami.bridges.ontologymanager.MIOntologyTermI;
@@ -28,11 +30,20 @@ import java.util.*;
 
 //TODO Deal with comments and URL
 public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
-    private TreeSet<psidev.psi.mi.jami.model.Annotation> sortedOntologyAnnotations;
-    private TreeSet<Annotation> sortedCvAnnotations;
+
+    private static final Log log = LogFactory.getLog(CvAnnotationUpdaterImpl.class);
+
+    private final TreeSet<psidev.psi.mi.jami.model.Annotation> sortedOntologyAnnotations;
+    private final TreeSet<Annotation> sortedCvAnnotations;
 
     // boolean value to know if url is in the annotations
     private boolean hasFoundURL = false;
+
+    // boolean value to know if search url is in the annotations
+    private boolean hasFoundSearchURL = false;
+
+    // boolean value to know if validation regex is in the annotations
+    private boolean hasFoundValidationRegexp = false;
     // boolean value to know if definition is in the annotations
     private boolean hasFoundDefinition = false;
     // boolean value to know if obsolete is in the annotations
@@ -45,20 +56,20 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
     private CvTopic cvTopic = null;
 
     // the comments to create
-    private Set<String> comments;
+    private final Set<String> comments;
 
     // the CvTopic for comment
     private CvTopic comment = null;
 
-    public CvAnnotationUpdaterImpl(){
+    public CvAnnotationUpdaterImpl() {
         sortedCvAnnotations = new TreeSet<>(new CvAnnotationComparator());
         sortedOntologyAnnotations = new TreeSet<>(new OntologyAnnotationComparator());
 
-        comments = new HashSet<String>();
+        comments = new HashSet<>();
     }
 
     @Transactional(propagation = Propagation.SUPPORTS)
-    public void updateAnnotations(CvUpdateContext updateContext, UpdatedEvent updateEvt){
+    public void updateAnnotations(CvUpdateContext updateContext, UpdatedEvent updateEvt) {
         DaoFactory factory = IntactContext.getCurrentInstance().getDaoFactory();
 
         MIOntologyTermI ontologyTerm = updateContext.getOntologyTerm();
@@ -72,7 +83,7 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
         sortedOntologyAnnotations.addAll(ontologyTerm.getDelegate().getAnnotations());
         Iterator<psidev.psi.mi.jami.model.Annotation> ontologyIterator = sortedOntologyAnnotations.iterator();
 
-        // the comments to create.
+        // All the comments to create from the ontology.
         // We extract only the value part for the comments to maintain the logic that was in the updater before
         // migrating CvUpdate to jami-ontology-manager.
         Collection<psidev.psi.mi.jami.model.Annotation> commentAnnotations = AnnotationUtils.collectAllAnnotationsHavingTopic(
@@ -82,470 +93,495 @@ public class CvAnnotationUpdaterImpl implements CvAnnotationUpdater {
             comments.add(commentAnnotation.getValue());
         }
 
-        if (intactIterator.hasNext() && ontologyIterator.hasNext()){
+        if (intactIterator.hasNext() && ontologyIterator.hasNext()) {
             currentIntact = intactIterator.next();
             currentOntologyRef = ontologyIterator.next();
             cvTopic = currentIntact.getCvTopic();
 
-            if (cvTopic != null){
-                do{
+            if (cvTopic != null) {
+                do {
                     int topicComparator = cvTopic.getIdentifier().compareTo(currentOntologyRef.getTopic().getMIIdentifier());
 
-                    // we have a db match
+                    // We have a db match, the annotation from Intact and from the ontology have the same topic
                     if (topicComparator == 0) {
-                        int acComparator;
-                        if (currentOntologyRef.getValue() == null && currentIntact.getAnnotationText() == null){
-                            acComparator = 0;
-                        }
-                        else if (currentOntologyRef.getValue() != null && currentIntact.getAnnotationText() == null){
-                            acComparator = -1;
-                        }
-                        else {
-                            acComparator = currentIntact.getAnnotationText().compareTo(currentOntologyRef.getValue());
-                        }
-
-                        // we have a primary id match
-                        if (acComparator == 0) {
-                            if (intactIterator.hasNext() && ontologyIterator.hasNext()){
-                                currentIntact = intactIterator.next();
-                                currentOntologyRef = ontologyIterator.next();
-                                cvTopic = currentIntact.getCvTopic();
-                            }
-                            else {
-                                currentIntact = null;
-                                currentOntologyRef = null;
-                                cvTopic = null;
-                            }
-                        }
-                        //intact has no match in ontology
-                        else if (acComparator < 0) {
-                            if (updateEvt != null){
-                                updateEvt.getDeletedAnnotations().add(currentIntact);
-
-                            }
-                            term.removeAnnotation(currentIntact);
-
-                            if (intactIterator.hasNext()){
-                                currentIntact = intactIterator.next();
-                                cvTopic = currentIntact.getCvTopic();
-                            }
-                            else {
-                                currentIntact = null;
-                                cvTopic = null;
-                            }
-                        }
-                        //ontology has no match in intact
-                        else {
-                            CvTopic cvTop = cvTopic;
-
-                            Annotation newAnnot = new Annotation(cvTop, currentOntologyRef.getValue());
-                            term.addAnnotation(newAnnot);
-
-                            if (updateEvt != null){
-                                updateEvt.getCreatedAnnotations().add(newAnnot);
-                            }
-
-                            if (ontologyIterator.hasNext()){
-                                currentOntologyRef = ontologyIterator.next();
-                            }
-                            else {
-                                currentOntologyRef = null;
-                            }
-                        }
+                        processAnnotationsWithMatchingTopic(factory, term, ontologyTerm, isObsolete, intactIterator, ontologyIterator, updateEvt);
                     }
-                    //intact has no match in ontology, we delete it excepted the identity xref
+                    // Annotation from Intact has no match in ontology, we check if we need to delete it or update it
                     else if (topicComparator < 0) {
-                        // we have a definition. Only one is allowed
-                        if (CvTopic.DEFINITION.equalsIgnoreCase(cvTopic.getShortLabel())){
-                            if (!hasFoundDefinition){
-                                hasFoundDefinition = true;
-
-                                // we update existing definition
-                                if (!ontologyTerm.getDelegate().getDefinition().equalsIgnoreCase(currentIntact.getAnnotationText())){
-                                    currentIntact.setAnnotationText(ontologyTerm.getDelegate().getDefinition());
-
-                                    if (updateEvt != null){
-                                        updateEvt.getUpdatedAnnotations().add(currentIntact); 
-                                    }
-                                }
-                            }
-                            else{
-                                if (updateEvt != null){
-                                    updateEvt.getDeletedAnnotations().add(currentIntact);
-                                }
-                                term.removeAnnotation(currentIntact);
-                            }
-                        }
-                        // we have an obsolete annotation. Only one is allowed
-                        else if (CvTopic.OBSOLETE_MI_REF.equalsIgnoreCase(cvTopic.getIdentifier())){
-                            if (!hasFoundObsolete && isObsolete){
-                                hasFoundObsolete = true;
-
-                                if (ontologyTerm.getObsoleteMessage() ==  null && currentIntact.getAnnotationText() != null){
-                                    currentIntact.setAnnotationText(null);
-
-                                    if (updateEvt != null){
-                                        updateEvt.getUpdatedAnnotations().add(currentIntact);
- 
-                                    }
-                                }
-                                else if (ontologyTerm.getObsoleteMessage() !=  null && !ontologyTerm.getObsoleteMessage().equalsIgnoreCase(currentIntact.getAnnotationText())){
-                                    currentIntact.setAnnotationText(ontologyTerm.getDelegate().getDefinition());
-
-                                    if (updateEvt != null){
-                                        updateEvt.getUpdatedAnnotations().add(currentIntact);
-                                    }
-                                }
-                            }
-                            else{
-                                if (updateEvt != null){
-                                    updateEvt.getDeletedAnnotations().add(currentIntact);
-                                }
-                                term.removeAnnotation(currentIntact);
-                            }
-                        }
-                        // the term is hidden. We do nothing for now
-                        else if (CvTopic.HIDDEN.equalsIgnoreCase(cvTopic.getShortLabel())){
-                            isHidden = true;
-                        }
-                        // we have a comment. Checks that it exists in the ontology
-                        else if (CvTopic.COMMENT_MI_REF.equalsIgnoreCase(cvTopic.getIdentifier())){
-                            comment = cvTopic;
-
-                            // comment exist
-                            if (comments.contains(currentIntact.getAnnotationText())){
-                                comments.remove(currentIntact.getAnnotationText());
-                            }
-                            // comment does not exist but can be updated
-                            else if (!comments.contains(currentIntact.getAnnotationText()) && comments.size() > 0){
-                                currentIntact.setAnnotationText(comments.iterator().next());
-
-                                if (updateEvt != null){
-                                    updateEvt.getUpdatedAnnotations().add(currentIntact);
-                                }
-
-                                comments.remove(currentIntact.getAnnotationText());
-                            }
-                            // delete the comment
-                            else {
-                                if (updateEvt != null){
-                                    updateEvt.getDeletedAnnotations().add(currentIntact);
-                                }
-                                term.removeAnnotation(currentIntact);
-                            }
-                        }
-                        // we have a url. Only one url is allowed
-                        else if (CvTopic.URL_MI_REF.equalsIgnoreCase(cvTopic.getIdentifier())){
-                            if (!hasFoundURL){
-                                hasFoundURL = true;
-
-                                if (!ontologyTerm.getDelegate().getDefinition().equalsIgnoreCase(currentIntact.getAnnotationText())){
-                                    currentIntact.setAnnotationText(ontologyTerm.getDelegate().getDefinition());
-
-                                    if (updateEvt != null){
-                                        updateEvt.getUpdatedAnnotations().add(currentIntact);
-
-                                    }
-                                }
-                            }
-                        }
-                        // checks specific annotations?
-                        else {
-
-                        }
-
-                        if (intactIterator.hasNext()){
-                            currentIntact = intactIterator.next();
-                            cvTopic = currentIntact.getCvTopic();
-                        }
-                        else {
-                            currentIntact = null;
-                            cvTopic = null;
-                        }
+                        processAnnotationWithNoMatchInOntology(term, ontologyTerm, isObsolete, updateEvt, intactIterator);
                     }
-                    //ontology xref has no match in intact, needs to create it
+                    // Annotation from ontology has no match in intact, needs to create it
                     else {
-                        CvTopic cvTop = factory.getCvObjectDao(CvTopic.class).getByIdentifier(currentOntologyRef.getTopic().getMIIdentifier());
-
-                        if (cvTop == null){
-                            cvTop = CvObjectUtils.createCvObject(IntactContext.getCurrentInstance().getInstitution(), CvTopic.class, currentOntologyRef.getTopic().getMIIdentifier(), currentOntologyRef.getTopic().getShortName());
-                            IntactContext.getCurrentInstance().getCorePersister().saveOrUpdate(cvTop);
-                        }
-
-                        Annotation newAnnot = new Annotation(cvTop, currentOntologyRef.getValue());
-                        term.addAnnotation(newAnnot);
-
-                        if (updateEvt != null){
-                            updateEvt.getCreatedAnnotations().add(newAnnot);
-                        }
-
-                        if (ontologyIterator.hasNext()){
-                            currentOntologyRef = ontologyIterator.next();
-                        }
-                        else {
-                            currentOntologyRef = null;
-                        }   currentOntologyRef = null;
+                        processMissingAnnotation(factory, term, updateEvt, ontologyIterator);
                     }
                 } while (currentIntact != null && currentOntologyRef != null && cvTopic != null);
             }
         }
 
         // need to delete specific remaining intact annotations, keeps the others
-        if (currentIntact != null || intactIterator.hasNext()){
-            if (currentIntact == null ){
+        if (currentIntact != null || intactIterator.hasNext()) {
+            if (currentIntact == null) {
                 currentIntact = intactIterator.next();
                 cvTopic = currentIntact.getCvTopic();
             }
 
             do {
-                // we have a definition. Only one is allowed
-                if (CvTopic.DEFINITION.equalsIgnoreCase(cvTopic.getShortLabel())){
-                    if (!hasFoundDefinition){
-                        hasFoundDefinition = true;
-
-                        // we update existing definition
-                        if ((ontologyTerm.getDelegate().getDefinition() != null && currentIntact.getAnnotationText() != null && !ontologyTerm.getDelegate().getDefinition().equalsIgnoreCase(currentIntact.getAnnotationText()))
-                                || (ontologyTerm.getDelegate().getDefinition() == null && currentIntact.getAnnotationText() != null) ||
-                                (ontologyTerm.getDelegate().getDefinition() != null && currentIntact.getAnnotationText() == null)){
-                            currentIntact.setAnnotationText(ontologyTerm.getDelegate().getDefinition());
-
-                            if (updateEvt != null){
-                                updateEvt.getUpdatedAnnotations().add(currentIntact);
-                            }
-                        }
-                    }
-                    else{
-                        if (updateEvt != null){
-                            updateEvt.getDeletedAnnotations().add(currentIntact);
-                        }
-                        term.removeAnnotation(currentIntact);
-                    }
-                }
-                // we have an obsolete annotation. Only one is allowed
-                else if (CvTopic.OBSOLETE_MI_REF.equalsIgnoreCase(cvTopic.getIdentifier())){
-                    if (!hasFoundObsolete && isObsolete){
-                        hasFoundObsolete = true;
-
-                        if (ontologyTerm.getObsoleteMessage() ==  null && currentIntact.getAnnotationText() != null){
-                            currentIntact.setAnnotationText(null);
-
-                            if (updateEvt != null){
-                                updateEvt.getUpdatedAnnotations().add(currentIntact); 
-                            }
-                        }
-                        else if (ontologyTerm.getObsoleteMessage() !=  null && !ontologyTerm.getObsoleteMessage().equalsIgnoreCase(currentIntact.getAnnotationText())){
-                            currentIntact.setAnnotationText(ontologyTerm.getDelegate().getDefinition());
-
-                            if (updateEvt != null){
-                                updateEvt.getUpdatedAnnotations().add(currentIntact);
-                            }
-                        }
-                    }
-                    else{
-                        if (updateEvt != null){
-                            updateEvt.getDeletedAnnotations().add(currentIntact);
-                        }
-                        term.removeAnnotation(currentIntact);
-                    }
-                }
-                // the term is hidden. We do nothing for now
-                else if (CvTopic.HIDDEN.equalsIgnoreCase(cvTopic.getShortLabel())){
-                    isHidden = true;
-                }
-                // we have a comment. Checks that it exists in the ontology
-                else if (CvTopic.COMMENT_MI_REF.equalsIgnoreCase(cvTopic.getIdentifier())){
-                    comment = cvTopic;
-
-                    // comment exist
-                    if (comments.contains(currentIntact.getAnnotationText())){
-                        comments.remove(currentIntact.getAnnotationText());
-                    }
-                    // comment does not exist but can be updated
-                    else if (!comments.contains(currentIntact.getAnnotationText()) && comments.size() > 0){
-                        currentIntact.setAnnotationText(comments.iterator().next());
-                        if (updateEvt != null){
-                            updateEvt.getUpdatedAnnotations().add(currentIntact);
-                        }
-
-                        comments.remove(currentIntact.getAnnotationText());
-                    }
-                    // delete the comment
-                    else {
-                        if (updateEvt != null){
-                            updateEvt.getDeletedAnnotations().add(currentIntact);
-                        }
-                        term.removeAnnotation(currentIntact);
-                    }
-                }
-                // we have a url. Only one url is allowed
-                else if (CvTopic.URL_MI_REF.equalsIgnoreCase(cvTopic.getIdentifier())){
-                    if (!hasFoundURL){
-                        hasFoundURL = true;
-
-                        if (!ontologyTerm.getDelegate().getDefinition().equalsIgnoreCase(currentIntact.getAnnotationText())){
-                            currentIntact.setAnnotationText(ontologyTerm.getDelegate().getDefinition());
-
-                            if (updateEvt != null){
-                                updateEvt.getUpdatedAnnotations().add(currentIntact);
-                            }
-                        }
-                    }
-                }
-                // checks specific annotations?
-                else {
-
-                }
-
-                if (intactIterator.hasNext()){
-                    currentIntact = intactIterator.next();
-                    cvTopic = currentIntact.getCvTopic();
-                }
-                else {
-                    currentIntact = null;
-                    cvTopic = null;
-                }
-            }while (currentIntact != null && cvTopic != null);
+                // Annotation from Intact has no match in ontology, we check if we need to delete it or update it
+                processAnnotationWithNoMatchInOntology(term, ontologyTerm, isObsolete, updateEvt, intactIterator);
+            } while (currentIntact != null && cvTopic != null);
         }
 
-        if (currentOntologyRef != null || ontologyIterator.hasNext()){
-            if (currentOntologyRef == null ){
+        // need to add annotations found in the ontology but missing in intact
+        if (currentOntologyRef != null || ontologyIterator.hasNext()) {
+            if (currentOntologyRef == null) {
                 currentOntologyRef = ontologyIterator.next();
             }
 
             do {
-                //ontology has no match in intact
-                CvTopic cvTop = factory.getCvObjectDao(CvTopic.class).getByIdentifier(currentOntologyRef.getTopic().getMIIdentifier());
-
-                if (cvTop == null){
-                    cvTop = CvObjectUtils.createCvObject(IntactContext.getCurrentInstance().getInstitution(), CvTopic.class, currentOntologyRef.getTopic().getMIIdentifier(), currentOntologyRef.getTopic().getShortName());
-                    IntactContext.getCurrentInstance().getCorePersister().saveOrUpdate(cvTop);
-                }
-
-                Annotation newAnnot = new Annotation(cvTop, currentOntologyRef.getValue());
-                term.addAnnotation(newAnnot);
-
-                if (updateEvt != null){
-                    updateEvt.getCreatedAnnotations().add(newAnnot);
-
-                }
-
-                if (ontologyIterator.hasNext()){
-                    currentOntologyRef = ontologyIterator.next();
-                }
-                else {
-                    currentOntologyRef = null;
-                }   currentOntologyRef = null;
-            }
-            while (currentOntologyRef != null);
+                // Annotation from ontology has no match in intact, needs to create it
+                processMissingAnnotation(factory, term, updateEvt, ontologyIterator);
+            } while (currentOntologyRef != null);
         }
 
-        // create missing definition
-        if (!hasFoundDefinition && ontologyTerm.getDelegate().getDefinition() != null){
-            CvTopic topicFromDb = factory.getCvObjectDao(CvTopic.class).getByShortLabel(CvTopic.DEFINITION);
-
-            if (topicFromDb == null){
-                topicFromDb = CvObjectUtils.createCvObject(IntactContext.getCurrentInstance().getInstitution(), CvTopic.class, null, CvTopic.DEFINITION);
-                IntactContext.getCurrentInstance().getCorePersister().saveOrUpdate(topicFromDb);
-            }
-
-            Annotation newAnnotation = new Annotation(topicFromDb, ontologyTerm.getDelegate().getDefinition());
-            term.addAnnotation(newAnnotation);
-
-            if (updateEvt != null){
-                updateEvt.getCreatedAnnotations().add(newAnnotation);
-            }
-        }
-
-//        // create missing url
-        psidev.psi.mi.jami.model.Annotation urlAnnotation = AnnotationUtils.collectFirstAnnotationWithTopic(
-                ontologyTerm.getDelegate().getAnnotations(),CvTopic.URL_MI_REF, CvTopic.URL);
-
-        if (!hasFoundURL && urlAnnotation != null){
-            CvTopic topicFromDb = factory.getCvObjectDao(CvTopic.class).getByIdentifier(CvTopic.URL_MI_REF);
-
-            if (topicFromDb == null){
-                topicFromDb = CvObjectUtils.createCvObject(IntactContext.getCurrentInstance().getInstitution(), CvTopic.class, CvTopic.URL_MI_REF, CvTopic.URL);
-                IntactContext.getCurrentInstance().getCorePersister().saveOrUpdate(topicFromDb);
-            }
-
-            Annotation newAnnotation = new Annotation(topicFromDb, urlAnnotation.getValue());
-            term.addAnnotation(newAnnotation);
-
-            if (updateEvt != null){
-                updateEvt.getCreatedAnnotations().add(newAnnotation);
-
-            }
-        }
-
-        // create missing obsolete
-        if (!hasFoundObsolete && isObsolete){
-            CvTopic topicFromDb = factory.getCvObjectDao(CvTopic.class).getByIdentifier(CvTopic.OBSOLETE_MI_REF);
-
-            if (topicFromDb == null){
-                topicFromDb = CvObjectUtils.createCvObject(IntactContext.getCurrentInstance().getInstitution(), CvTopic.class, CvTopic.OBSOLETE_MI_REF, CvTopic.OBSOLETE);
-                IntactContext.getCurrentInstance().getCorePersister().saveOrUpdate(topicFromDb);
-            }
-
-            Annotation newAnnotation = new Annotation(topicFromDb, ontologyTerm.getObsoleteMessage());
-            term.addAnnotation(newAnnotation);
-
-            if (updateEvt != null){
-                updateEvt.getCreatedAnnotations().add(newAnnotation);
-            }
-        }
-
-        // hide term if obsolete
-        if (isObsolete && !isHidden){
-            Annotation hidden = CvUpdateUtils.hideTerm(term, "obsolete term");
-
-            if (updateEvt != null){
-                updateEvt.getCreatedAnnotations().add(hidden);
-            }
-        }
-
-        // create missing comments
-        if (!comments.isEmpty()){
-            if (comment == null){
-                comment = factory.getCvObjectDao(CvTopic.class).getByIdentifier(CvTopic.COMMENT_MI_REF);
-
-                if (comment == null){
-                    comment = CvObjectUtils.createCvObject(IntactContext.getCurrentInstance().getInstitution(), CvTopic.class, CvTopic.COMMENT_MI_REF, CvTopic.COMMENT);
-                    IntactContext.getCurrentInstance().getCorePersister().saveOrUpdate(comment);
-                }
-            }
-
-            for (String com : comments){
-                Annotation newAnnotation = new Annotation(comment, com);
-                term.addAnnotation(newAnnotation);
-
-                if (updateEvt != null){
-                    updateEvt.getCreatedAnnotations().add(newAnnotation);
-                }
-            }
-        }
+        // Create expected annotations that are missing, such as description or url
+        // All these annotation should had been created or updated already, but we double-check here just in case
+        createMissingAnnotations(factory, term, ontologyTerm, updateEvt, isObsolete);
 
         clear();
     }
 
-    public void clear(){
+    public void clear() {
         sortedOntologyAnnotations.clear();
         sortedCvAnnotations.clear();
         hasFoundURL = false;
-        // boolean value to know if definition is in the annotations
+        hasFoundSearchURL = false;
+        hasFoundValidationRegexp = false;
         hasFoundDefinition = false;
-        // boolean value to know if obsolete is in the annotations
         hasFoundObsolete = false;
-        // boolean value to know if hidden is in the annotations
         isHidden = false;
 
         currentIntact = null;
         currentOntologyRef = null;
         cvTopic = null;
 
-        // the comments to create
-//        comments.clear();
+        comments.clear();
 
-        // the CvTopic for comment
         comment = null;
+    }
+
+    private void processAnnotationsWithMatchingTopic(
+            DaoFactory factory,
+            CvDagObject term,
+            MIOntologyTermI ontologyTerm,
+            boolean isObsolete,
+            Iterator<Annotation> intactIterator,
+            Iterator<psidev.psi.mi.jami.model.Annotation> ontologyIterator,
+            UpdatedEvent updateEvt) {
+
+        int acComparator;
+        if (currentOntologyRef.getValue() == null && currentIntact.getAnnotationText() == null) {
+            acComparator = 0;
+        }
+        else if (currentOntologyRef.getValue() != null && currentIntact.getAnnotationText() == null) {
+            acComparator = -1;
+        }
+        else {
+            acComparator = currentIntact.getAnnotationText().compareTo(currentOntologyRef.getValue());
+        }
+
+        // We have an exact match, the annotation from Intact and from the ontology contain the same text
+        if (acComparator == 0) {
+            processAnnotationsWithExactMatch(intactIterator, ontologyIterator);
+        }
+        // Annotation from Intact has no match in ontology, we need to delete it
+        else if (acComparator < 0) {
+            processAnnotationWithNoMatchInOntology(term, ontologyTerm, isObsolete, updateEvt, intactIterator);
+        }
+        // Annotation from ontology has no match in Intact, we need to add it
+        else {
+            processMissingAnnotation(factory, term, updateEvt, ontologyIterator);
+        }
+    }
+
+    private void processAnnotationsWithExactMatch(
+            Iterator<Annotation> intactIterator,
+            Iterator<psidev.psi.mi.jami.model.Annotation> ontologyIterator) {
+
+        // we have a definition. Only one is allowed
+        if (CvTopic.DEFINITION.equalsIgnoreCase(cvTopic.getShortLabel())) {
+            hasFoundDefinition = true;
+        }
+        // we have a definition. Only one is allowed
+        else if (CvTopic.URL.equalsIgnoreCase(cvTopic.getShortLabel())) {
+            hasFoundURL = true;
+        }
+        // we have a definition. Only one is allowed
+        else if (CvTopic.SEARCH_URL.equalsIgnoreCase(cvTopic.getShortLabel())) {
+            hasFoundSearchURL = true;
+        }
+        // we have a definition. Only one is allowed
+        else if (CvTopic.XREF_VALIDATION_REGEXP.equalsIgnoreCase(cvTopic.getShortLabel())) {
+            hasFoundValidationRegexp = true;
+        }
+        // we have a definition. Only one is allowed
+        else if (CvTopic.OBSOLETE.equalsIgnoreCase(cvTopic.getShortLabel())) {
+            hasFoundObsolete = true;
+        }
+
+        if (intactIterator.hasNext() && ontologyIterator.hasNext()) {
+            currentIntact = intactIterator.next();
+            currentOntologyRef = ontologyIterator.next();
+            cvTopic = currentIntact.getCvTopic();
+        }
+        else {
+            currentIntact = null;
+            currentOntologyRef = null;
+            cvTopic = null;
+        }
+    }
+
+    private void processAnnotationWithNoMatchInOntology(
+            CvDagObject term,
+            MIOntologyTermI ontologyTerm,
+            boolean isObsolete,
+            UpdatedEvent updateEvt,
+            Iterator<Annotation> intactIterator) {
+
+        // we have a definition. Only one is allowed
+        if (CvTopic.DEFINITION.equalsIgnoreCase(cvTopic.getShortLabel())) {
+            if (!hasFoundDefinition) {
+                hasFoundDefinition = true;
+
+                // we update existing definition annotation with new text from ontology
+                if (!ontologyTerm.getDelegate().getDefinition().equalsIgnoreCase(currentIntact.getAnnotationText())) {
+                    log.info("TESTING - Definition updated for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                    updateAnnotation(updateEvt, ontologyTerm.getDelegate().getDefinition());
+                }
+            }
+            else {
+                // One definition annotation has been found already, we delete the extra ones
+                log.info("TESTING - Definition deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                deleteAnnotation(term, updateEvt);
+            }
+        }
+        // we have an obsolete annotation. Only one is allowed
+        else if (CvTopic.OBSOLETE_MI_REF.equalsIgnoreCase(cvTopic.getIdentifier())) {
+            if (!hasFoundObsolete && isObsolete) {
+                hasFoundObsolete = true;
+
+                // we update existing obsolete annotation with new text from ontology
+                if (ontologyTerm.getObsoleteMessage() ==  null && currentIntact.getAnnotationText() != null) {
+                    log.info("TESTING - Obsolete updated for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                    updateAnnotation(updateEvt, null);
+                }
+                else if (ontologyTerm.getObsoleteMessage() !=  null && !ontologyTerm.getObsoleteMessage().equalsIgnoreCase(currentIntact.getAnnotationText())){
+                    updateAnnotation(updateEvt, ontologyTerm.getObsoleteMessage());
+                }
+            }
+            else{
+                // One obsolete annotation has been found already, we delete the extra ones
+                log.info("TESTING - Obsolete deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                deleteAnnotation(term, updateEvt);
+            }
+        }
+        // the term is hidden. We do nothing for now
+        else if (CvTopic.HIDDEN.equalsIgnoreCase(cvTopic.getShortLabel())) {
+            isHidden = true;
+        }
+        // we have a comment. Checks that it exists in the ontology
+        else if (CvTopic.COMMENT_MI_REF.equalsIgnoreCase(cvTopic.getIdentifier())) {
+            comment = cvTopic;
+
+            // comment exist in the ontology
+            if (comments.contains(currentIntact.getAnnotationText())) {
+                comments.remove(currentIntact.getAnnotationText());
+            }
+            // comment does not exist but can be updated with a newer comment from the ontology
+            else if (!comments.contains(currentIntact.getAnnotationText()) && !comments.isEmpty()) {
+                log.info("TESTING - Comment updated for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                updateAnnotation(updateEvt, comments.iterator().next());
+
+                comments.remove(currentIntact.getAnnotationText());
+            }
+            // delete the comment annotation, as it does not exist in the ontology
+            else {
+                log.info("TESTING - Comment deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                deleteAnnotation(term, updateEvt);
+            }
+        }
+        // we have a url. Only one url is allowed
+        else if (CvTopic.URL_MI_REF.equalsIgnoreCase(cvTopic.getIdentifier())) {
+            if (!hasFoundURL) {
+                // we update existing url annotation with new text from ontology
+                log.info("TESTING - Url updated for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                hasFoundURL = updateAnnotationIfFoundInOntology(ontologyTerm, updateEvt, CvTopic.URL_MI_REF, CvTopic.URL);
+            }
+            else {
+                // One url annotation has been found already, we delete the extra ones
+                log.info("TESTING - Url deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                deleteAnnotation(term, updateEvt);
+            }
+        }
+        // we have a search url. Only one search url is allowed
+        else if (CvTopic.SEARCH_URL_MI_REF.equalsIgnoreCase(cvTopic.getIdentifier())) {
+            if (!hasFoundSearchURL) {
+                // we update existing search url annotation with new text from ontology
+                log.info("TESTING - Search url updated for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                hasFoundSearchURL = updateAnnotationIfFoundInOntology(
+                        ontologyTerm, updateEvt, CvTopic.SEARCH_URL_MI_REF, CvTopic.SEARCH_URL);
+            }
+            else {
+                // One search url annotation has been found already, we delete the extra ones
+                log.info("TESTING - Search url deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                deleteAnnotation(term, updateEvt);
+            }
+        }
+        // we have a validation regex. Only one validation regex is allowed
+        else if (CvTopic.XREF_VALIDATION_REGEXP_MI_REF.equalsIgnoreCase(cvTopic.getIdentifier())) {
+            if (!hasFoundValidationRegexp) {
+                // we update existing validation regex annotation with new text from ontology
+                log.info("TESTING - Validation regex updated for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                hasFoundValidationRegexp = updateAnnotationIfFoundInOntology(
+                        ontologyTerm, updateEvt, CvTopic.XREF_VALIDATION_REGEXP_MI_REF, CvTopic.XREF_VALIDATION_REGEXP);
+            }
+            else {
+                // One validation regex annotation has been found already, we delete the extra ones
+                log.info("TESTING - Validation regex deleted for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                deleteAnnotation(term, updateEvt);
+            }
+        }
+
+        if (intactIterator.hasNext()){
+            currentIntact = intactIterator.next();
+            cvTopic = currentIntact.getCvTopic();
+        }
+        else {
+            currentIntact = null;
+            cvTopic = null;
+        }
+    }
+
+    private void processMissingAnnotation(
+            DaoFactory factory,
+            CvDagObject term,
+            UpdatedEvent updateEvt,
+            Iterator<psidev.psi.mi.jami.model.Annotation> ontologyIterator) {
+
+        CvTopic cvTop = factory.getCvObjectDao(CvTopic.class).getByIdentifier(currentOntologyRef.getTopic().getMIIdentifier());
+
+        if (cvTop == null) {
+            cvTop = CvObjectUtils.createCvObject(IntactContext.getCurrentInstance().getInstitution(), CvTopic.class, currentOntologyRef.getTopic().getMIIdentifier(), currentOntologyRef.getTopic().getShortName());
+            IntactContext.getCurrentInstance().getCorePersister().saveOrUpdate(cvTop);
+        }
+
+        createNewAnnotationFromOntology(cvTop, term, updateEvt, ontologyIterator);
+    }
+
+    private void createNewAnnotationFromOntology(
+            CvTopic cvTop,
+            CvDagObject term,
+            UpdatedEvent updateEvt,
+            Iterator<psidev.psi.mi.jami.model.Annotation> ontologyIterator) {
+
+        // we have a definition. Only one is allowed
+        if (CvTopic.DEFINITION.equalsIgnoreCase(cvTop.getShortLabel())) {
+            if (!hasFoundDefinition) {
+                hasFoundDefinition = true;
+                log.info("TESTING - Definition created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                createNewAnnotation(cvTop, term, updateEvt, currentOntologyRef.getValue());
+            }
+        }
+        // we have a definition. Only one is allowed
+        else if (CvTopic.URL.equalsIgnoreCase(cvTop.getShortLabel())) {
+            if (!hasFoundURL) {
+                hasFoundURL = true;
+                log.info("TESTING - Url created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                createNewAnnotation(cvTop, term, updateEvt, currentOntologyRef.getValue());
+            }
+        }
+        // we have a definition. Only one is allowed
+        else if (CvTopic.SEARCH_URL.equalsIgnoreCase(cvTop.getShortLabel())) {
+            if (!hasFoundSearchURL) {
+                hasFoundSearchURL = true;
+                log.info("TESTING - Search url created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                createNewAnnotation(cvTop, term, updateEvt, currentOntologyRef.getValue());
+            }
+        }
+        // we have a definition. Only one is allowed
+        else if (CvTopic.XREF_VALIDATION_REGEXP.equalsIgnoreCase(cvTop.getShortLabel())) {
+            if (!hasFoundValidationRegexp) {
+                hasFoundValidationRegexp = true;
+                log.info("TESTING - Validation regex created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                createNewAnnotation(cvTop, term, updateEvt, currentOntologyRef.getValue());
+            }
+        }
+        // we have a definition. Only one is allowed
+        else if (CvTopic.OBSOLETE.equalsIgnoreCase(cvTop.getShortLabel())) {
+            if (!hasFoundObsolete) {
+                hasFoundObsolete = true;
+                log.info("TESTING - Obsolete created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                createNewAnnotation(cvTop, term, updateEvt, currentOntologyRef.getValue());
+            }
+        }
+        // we have a comment, we remove it from the list of comments to create and add it to Intact
+        else if (CvTopic.COMMENT_MI_REF.equalsIgnoreCase(cvTop.getIdentifier())) {
+            comment = cvTop;
+            comments.remove(currentOntologyRef.getValue());
+            log.info("TESTING - Comment created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+            createNewAnnotation(cvTop, term, updateEvt, currentOntologyRef.getValue());
+        }
+        // we have another type of annotation, we simply create it in Intact
+        else {
+            log.info("TESTING - Other (Topic = " + cvTop.getShortLabel() + ") created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+            createNewAnnotation(cvTop, term, updateEvt, currentOntologyRef.getValue());
+        }
+
+        if (ontologyIterator.hasNext()) {
+            currentOntologyRef = ontologyIterator.next();
+        } else {
+            currentOntologyRef = null;
+        }
+    }
+
+    private void createMissingAnnotations(
+            DaoFactory factory,
+            CvDagObject term,
+            MIOntologyTermI ontologyTerm,
+            UpdatedEvent updateEvt,
+            boolean isObsolete) {
+
+        // create missing definition
+        if (!hasFoundDefinition && ontologyTerm.getDelegate().getDefinition() != null) {
+            log.info("TESTING - Missing definition created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+            createNewAnnotationWithTopic(factory, term, updateEvt, ontologyTerm.getDelegate().getDefinition(), null, CvTopic.DEFINITION);
+        }
+
+        // create missing url
+        psidev.psi.mi.jami.model.Annotation urlAnnotation = AnnotationUtils.collectFirstAnnotationWithTopic(
+                ontologyTerm.getDelegate().getAnnotations(),CvTopic.URL_MI_REF, CvTopic.URL);
+
+        if (!hasFoundURL && urlAnnotation != null) {
+            log.info("TESTING - Missing url created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+            createNewAnnotationWithTopic(factory, term, updateEvt, urlAnnotation.getValue(), CvTopic.URL_MI_REF, CvTopic.URL);
+        }
+
+        // create missing search url
+        psidev.psi.mi.jami.model.Annotation searchUrlAnnotation = AnnotationUtils.collectFirstAnnotationWithTopic(
+                ontologyTerm.getDelegate().getAnnotations(),CvTopic.SEARCH_URL_MI_REF, CvTopic.SEARCH_URL);
+
+        if (!hasFoundSearchURL && searchUrlAnnotation != null) {
+            log.info("TESTING - Missing search url created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+            createNewAnnotationWithTopic(factory, term, updateEvt, searchUrlAnnotation.getValue(), CvTopic.SEARCH_URL_MI_REF, CvTopic.SEARCH_URL);
+        }
+
+        // create missing validation regex
+        psidev.psi.mi.jami.model.Annotation validationRegexAnnotation = AnnotationUtils.collectFirstAnnotationWithTopic(
+                ontologyTerm.getDelegate().getAnnotations(),CvTopic.XREF_VALIDATION_REGEXP_MI_REF, CvTopic.XREF_VALIDATION_REGEXP);
+
+        if (!hasFoundValidationRegexp && validationRegexAnnotation != null) {
+            log.info("TESTING - Missing validation regex created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+            createNewAnnotationWithTopic(factory, term, updateEvt, validationRegexAnnotation.getValue(), CvTopic.XREF_VALIDATION_REGEXP_MI_REF, CvTopic.XREF_VALIDATION_REGEXP);
+        }
+
+        // create missing obsolete
+        if (!hasFoundObsolete && isObsolete) {
+            log.info("TESTING - Missing obsolete created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+            createNewAnnotationWithTopic(factory, term, updateEvt, ontologyTerm.getObsoleteMessage(), CvTopic.OBSOLETE_MI_REF, CvTopic.OBSOLETE);
+        }
+
+        // hide term if obsolete
+        if (isObsolete && !isHidden) {
+            log.info("TESTING - Missing old obsolete created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+            Annotation hidden = CvUpdateUtils.hideTerm(term, CvTopic.OBSOLETE_OLD);
+
+            if (updateEvt != null) {
+                updateEvt.getCreatedAnnotations().add(hidden);
+            }
+        }
+
+        // create missing comments that have not been created or updated yet
+        if (!comments.isEmpty()) {
+            if (comment == null) {
+                comment = factory.getCvObjectDao(CvTopic.class).getByIdentifier(CvTopic.COMMENT_MI_REF);
+
+                if (comment == null) {
+                    comment = CvObjectUtils.createCvObject(IntactContext.getCurrentInstance().getInstitution(), CvTopic.class, CvTopic.COMMENT_MI_REF, CvTopic.COMMENT);
+                    IntactContext.getCurrentInstance().getCorePersister().saveOrUpdate(comment);
+                }
+            }
+
+            for (String com : comments) {
+                log.info("TESTING - Missing comment created for term (AC = " + term.getAc() + ", label = " + term.getShortLabel() + ")");
+                createNewAnnotation(comment, term, updateEvt, com);
+            }
+        }
+    }
+
+    private void createNewAnnotationWithTopic(
+            DaoFactory factory,
+            CvDagObject term,
+            UpdatedEvent updateEvt,
+            String annotationText,
+            String topicId,
+            String topicName) {
+
+        CvTopic topicFromDb;
+        if (topicId != null) {
+            topicFromDb = factory.getCvObjectDao(CvTopic.class).getByIdentifier(topicId);
+        } else {
+            topicFromDb = factory.getCvObjectDao(CvTopic.class).getByShortLabel(topicName);
+        }
+
+        if (topicFromDb == null) {
+            topicFromDb = CvObjectUtils.createCvObject(IntactContext.getCurrentInstance().getInstitution(), CvTopic.class, topicId, topicName);
+            IntactContext.getCurrentInstance().getCorePersister().saveOrUpdate(topicFromDb);
+        }
+
+        createNewAnnotation(topicFromDb, term, updateEvt, annotationText);
+    }
+
+    private boolean updateAnnotationIfFoundInOntology(
+            MIOntologyTermI ontologyTerm,
+            UpdatedEvent updateEvt,
+            String topicId,
+            String topicName) {
+
+        psidev.psi.mi.jami.model.Annotation annotation = AnnotationUtils.collectFirstAnnotationWithTopic(
+                ontologyTerm.getDelegate().getAnnotations(), topicId, topicName);
+
+        if (annotation != null) {
+            updateAnnotation(updateEvt, annotation.getValue());
+            return true;
+        }
+        return false;
+    }
+
+    private void createNewAnnotation(
+            CvTopic cvTop,
+            CvDagObject term,
+            UpdatedEvent updateEvt,
+            String annotationText) {
+
+        Annotation newAnnot = new Annotation(cvTop, annotationText);
+        term.addAnnotation(newAnnot);
+
+        if (updateEvt != null) {
+            updateEvt.getCreatedAnnotations().add(newAnnot);
+        }
+    }
+
+    private void updateAnnotation(UpdatedEvent updateEvt, String annotationText) {
+        currentIntact.setAnnotationText(annotationText);
+
+        if (updateEvt != null) {
+            updateEvt.getUpdatedAnnotations().add(currentIntact);
+        }
+    }
+
+    private void deleteAnnotation(CvDagObject term, UpdatedEvent updateEvt) {
+        if (updateEvt != null) {
+            updateEvt.getDeletedAnnotations().add(currentIntact);
+        }
+        term.removeAnnotation(currentIntact);
     }
 }

--- a/intact-cv-update/src/main/java/uk/ac/ebi/intact/dbupdate/cv/utils/CvAnnotationComparator.java
+++ b/intact-cv-update/src/main/java/uk/ac/ebi/intact/dbupdate/cv/utils/CvAnnotationComparator.java
@@ -12,58 +12,71 @@ import java.util.Comparator;
  * @since <pre>22/11/11</pre>
  */
 
-public class CvAnnotationComparator implements Comparator<Annotation>{
+public class CvAnnotationComparator implements Comparator<Annotation> {
+
+    private static final int BEFORE = -1;
+    private static final  int EQUAL = 0;
+    private static final  int AFTER = 1;
+
     @Override
     public int compare(Annotation o1, Annotation o2) {
-        final int BEFORE = -1;
-        final int EQUAL = 0;
-        final int AFTER = 1;
 
         // both have a topic
-        if (o1.getCvTopic() != null && o2.getCvTopic() != null){
+        if (o1.getCvTopic() != null && o2.getCvTopic() != null) {
             // topic identical, we can sort by text
-            if (o1.getCvTopic().getIdentifier().equalsIgnoreCase(o2.getCvTopic().getIdentifier())){
-
-                // both have a text
-                if (o1.getAnnotationText() != null && o2.getAnnotationText() != null){
-                    return o1.getAnnotationText().compareTo(o2.getAnnotationText());
-                }
-                else if (o1.getAnnotationText() == null && o2.getAnnotationText() != null){
-                    return AFTER;
-                }
-                else if (o1.getAnnotationText()!= null && o2.getAnnotationText() == null){
-                    return BEFORE;
-                }
-                else {
-                    return EQUAL;
-                }
+            if (o1.getCvTopic().getIdentifier().equalsIgnoreCase(o2.getCvTopic().getIdentifier())) {
+                return compareByText(o1, o2);
             }
             // topics are different, we sort first by topics
             else {
                 return o1.getCvTopic().getIdentifier().compareTo(o2.getCvTopic().getIdentifier());
             }
         }
-        else if (o1.getCvTopic() == null && o2.getCvTopic() != null){
+        else if (o1.getCvTopic() == null && o2.getCvTopic() != null) {
             return AFTER;
         }
-        else if (o1.getCvTopic() != null && o2.getCvTopic()== null){
+        else if (o1.getCvTopic() != null && o2.getCvTopic()== null) {
             return BEFORE;
         }
         else {
+            return compareByText(o1, o2);
+        }
+    }
 
-            // both have a text
-            if (o1.getAnnotationText() != null && o2.getAnnotationText() != null){
+    private int compareByText(Annotation o1, Annotation o2) {
+        // both have a text
+        if (o1.getAnnotationText() != null && o2.getAnnotationText() != null) {
+            // text identical, we can sort by AC
+            if (o1.getAnnotationText().compareTo(o2.getAnnotationText()) == EQUAL) {
+                return compareByAc(o1, o2);
+            } else {
                 return o1.getAnnotationText().compareTo(o2.getAnnotationText());
             }
-            else if (o1.getAnnotationText() == null && o2.getAnnotationText() != null){
-                return AFTER;
-            }
-            else if (o1.getAnnotationText()!= null && o2.getAnnotationText() == null){
-                return BEFORE;
-            }
-            else {
-                return EQUAL;
-            }
+        }
+        else if (o1.getAnnotationText() == null && o2.getAnnotationText() != null) {
+            return AFTER;
+        }
+        else if (o1.getAnnotationText()!= null && o2.getAnnotationText() == null) {
+            return BEFORE;
+        }
+        else {
+            return compareByAc(o1, o2);
+        }
+    }
+
+    private int compareByAc(Annotation o1, Annotation o2) {
+        // both have AC
+        if (o1.getAc() != null && o2.getAc() != null) {
+            return o1.getAc().compareTo(o2.getAc());
+        }
+        else if (o1.getAc() == null && o2.getAc() != null) {
+            return AFTER;
+        }
+        else if (o1.getAc()!= null && o2.getAc() == null) {
+            return BEFORE;
+        }
+        else {
+            return EQUAL;
         }
     }
 }

--- a/intact-datasets-update/pom.xml
+++ b/intact-datasets-update/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dbupdate-master</artifactId>
         <groupId>uk.ac.ebi.intact.dbupdate</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-datasets-update</artifactId>

--- a/intact-genes-update/pom.xml
+++ b/intact-genes-update/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>dbupdate-master</artifactId>
         <groupId>uk.ac.ebi.intact.dbupdate</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/intact-mutation-update/pom.xml
+++ b/intact-mutation-update/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dbupdate</groupId>
         <artifactId>dbupdate-master</artifactId>
-        <version>2.3.3</version>
+        <version>2.3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-mutation-update</artifactId>

--- a/intact-proteins-update/pom.xml
+++ b/intact-proteins-update/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dbupdate</groupId>
         <artifactId>dbupdate-master</artifactId>
-        <version>2.3.3</version>
+        <version>2.3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-proteins-update</artifactId>

--- a/intact-update-model/pom.xml
+++ b/intact-update-model/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dbupdate</groupId>
         <artifactId>dbupdate-master</artifactId>
-        <version>2.3.3</version>
+        <version>2.3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-update-model</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <groupId>uk.ac.ebi.intact.dbupdate</groupId>
     <artifactId>dbupdate-master</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.3</version>
+    <version>2.3.4-SNAPSHOT</version>
 
     <name>IntAct Database Update</name>
     <description>Database Update Master POM</description>


### PR DESCRIPTION
CV update process was not properly updating certain annotations like validation regex or search url. It was also not removing old annotations, like definitions or urls, when new ones were being added,; even though only one annotation with this topic is allowed per term.

Most of the changes are in CvAnnotationUpdaterImpl.java, but the diff is big, as I split one huge method into multiple one for re-usability and readability.

The changes consist on:
- For annotations with topic description, url, search url, validation regex or obsolete:
  - If the annotation in Intact requires an update from the ontology, update it
  - If the annotation does not exist in Intact, create it
  - If there are multiple annotations in Intact, delete the extra ones
- For other annotations, the logic remains the same

Because of multiple annotations with the same topic and the same text possibly existing in Intact, I also updated the comparator to take the AC into account, so we iterate through ALL of them, and we don't ignore duplicates.

These changes were tested in test and dev; and then they were ran in prod. All the changes have been reviewed and they are working as expected.